### PR TITLE
Add support for --commit arg to create

### DIFF
--- a/.changelog/b8289034914a4c72a4f15bb6dd76dd2c.md
+++ b/.changelog/b8289034914a4c72a4f15bb6dd76dd2c.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add support for --commit arg to create

--- a/changelet/command/create.py
+++ b/changelet/command/create.py
@@ -43,6 +43,13 @@ See https://semver.org/ for more info''',
             help='`git add` the newly created changelog entry',
         )
         parser.add_argument(
+            '-c',
+            '--commit',
+            action='store_true',
+            default=False,
+            help='`git commit` add the entry and commit staged changes using the same description',
+        )
+        parser.add_argument(
             'description',
             metavar='change-description',
             nargs='+',
@@ -53,19 +60,26 @@ and links.''',
 
     def run(self, args, config):
         filename = join(config.directory, f'{uuid4().hex}.md')
+        description = ' '.join(args.description)
         entry = Entry(
             type=args.type,
-            description=' '.join(args.description),
+            description=description,
             pr=args.pr,
             filename=filename,
         )
         entry.save()
 
-        if args.add:
+        if args.add or args.commit:
             config.provider.add_file(entry.filename)
-            print(
-                f'Created {entry.filename}, it has been staged and should be committed to your branch.'
-            )
+            if args.commit:
+                config.provider.commit(description)
+                print(
+                    f'Created {entry.filename}, it has been committed along with staged changes.'
+                )
+            else:
+                print(
+                    f'Created {entry.filename}, it has been staged and should be committed to your branch.'
+                )
         else:
             print(
                 f'Created {entry.filename}, it can be further edited and should be committed to your branch.'

--- a/changelet/github.py
+++ b/changelet/github.py
@@ -90,5 +90,8 @@ class GitHubCli:
     def add_file(self, filename):
         run(['git', 'add', filename], check=True)
 
+    def commit(self, description):
+        run(['git', 'commit', '-m', description], check=True)
+
     def __repr__(self):
         return f'GitHubCli<repo={self.repo}, max_lookback={self.max_lookback}>'

--- a/tests/test_command_create.py
+++ b/tests/test_command_create.py
@@ -47,11 +47,14 @@ class TestCommandCreate(TestCase, AssertActionMixin):
 
         class ArgsMock:
 
-            def __init__(self, type, description, pr=None, add=False):
+            def __init__(
+                self, type, description, pr=None, add=False, commit=False
+            ):
                 self.type = type
                 self.description = description
                 self.pr = pr
                 self.add = add
+                self.commit = commit
 
         with TemporaryDirectory() as td:
             type = 'patch'
@@ -90,3 +93,12 @@ class TestCommandCreate(TestCase, AssertActionMixin):
             self.assertNotEqual(filename, new_filename)
             save_mock.assert_called_once()
             provider_mock.add_file.assert_called_once_with(new_filename)
+
+            # commit
+            provider_mock.reset_mock()
+            args.add = False
+            args.commit = True
+            entry = create.run(args, config)
+            new_filename = entry.filename
+            provider_mock.add_file.assert_called_once_with(new_filename)
+            provider_mock.commit.assert_called_once_with(description)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -174,3 +174,14 @@ class TestGitHubCli(TestCase):
         run_mock.assert_called_once()
         args = run_mock.call_args[0][0]
         self.assertTrue(filename in args)
+
+    @patch('changelet.github.run')
+    def test_commit(self, run_mock):
+        gh = GitHubCli()
+        description = 'Hello World'
+
+        run_mock.reset_mock()
+        gh.commit(description)
+        run_mock.assert_called_once()
+        args = run_mock.call_args[0][0]
+        self.assertTrue(description in args)


### PR DESCRIPTION
```console
(env) ross@trout:~/octodns/changelet $ ./script/changelog create -c -t minor -- Add support for --commit arg to create
...
Created .changelog/b8289034914a4c72a4f15bb6dd76dd2c.md, it has been committed along with staged changes.
```