### PR TITLE
Release 0.2.0 version bump & changelog update

### DIFF
--- a/.changelog/35e6341e3c344d7e8ad5545d2a8b87f3.md
+++ b/.changelog/35e6341e3c344d7e8ad5545d2a8b87f3.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add --quiet flag to create

--- a/.changelog/b157733e5b8246f981d49c60033cd397.md
+++ b/.changelog/b157733e5b8246f981d49c60033cd397.md
@@ -1,4 +1,0 @@
----
-type: none
----
-example tweaks

--- a/.changelog/b8289034914a4c72a4f15bb6dd76dd2c.md
+++ b/.changelog/b8289034914a4c72a4f15bb6dd76dd2c.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add support for --commit arg to create

--- a/.changelog/e1ee2930ec4f461eaea886898f288524.md
+++ b/.changelog/e1ee2930ec4f461eaea886898f288524.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix org and repo in PR urls

--- a/.changelog/e58bf2b76f3745a7a907b045440e6c16.md
+++ b/.changelog/e58bf2b76f3745a7a907b045440e6c16.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add support for --logging cmdline arg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.2.0 - 2025-08-15
+
+Minor:
+* Add support for --logging cmdline arg - [#11](https://github.com/octodns/changelet/pull/11)
+* Add --quiet flag to create - [#10](https://github.com/octodns/changelet/pull/10)
+* Add support for --commit arg to create - [#9](https://github.com/octodns/changelet/pull/9)
+
+Patch:
+* Fix org and repo in PR urls - [#12](https://github.com/octodns/changelet/pull/12)
+
 ## 0.1.0 - 2025-07-26
 
 Major:

--- a/changelet/__init__.py
+++ b/changelet/__init__.py
@@ -2,4 +2,4 @@
 #
 #
 
-__version__ = __VERSION__ = '0.1.0'
+__version__ = __VERSION__ = '0.2.0'


### PR DESCRIPTION
## 0.2.0 - 2025-08-15

Minor:
* Add support for --logging cmdline arg - [#11](https://github.com/octodns/changelet/pull/11)
* Add --quiet flag to create - [#10](https://github.com/octodns/changelet/pull/10)
* Add support for --commit arg to create - [#9](https://github.com/octodns/changelet/pull/9)

Patch:
* Fix org and repo in PR urls - [#12](https://github.com/octodns/changelet/pull/12)