### PR TITLE
Add commit prefix for changelog only commits

### DIFF
--- a/.changelog/ca8c7bff991043fea1cee4ffb5456fe7.md
+++ b/.changelog/ca8c7bff991043fea1cee4ffb5456fe7.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add commit prefix for changelog only commits

--- a/changelet/command/create.py
+++ b/changelet/command/create.py
@@ -72,6 +72,9 @@ and links.''',
         if args.add or args.commit:
             config.provider.add_file(entry.filename)
             if args.commit:
+                if not config.provider.has_staged():
+                    # if this is going to be a changelog only commit, prefix it
+                    description = f'{config.commit_prefix}{description}'
                 config.provider.commit(description)
                 print(
                     f'Created {entry.filename}, it has been committed along with staged changes.'

--- a/changelet/config.py
+++ b/changelet/config.py
@@ -64,10 +64,12 @@ class Config:
         self,
         root=DEFAULT_ROOT,
         directory='.changelog',
+        commit_prefix='Changelog: ',
         provider={'class': 'changelet.github.GitHubCli'},
     ):
         self.root = root
         self.directory = directory
+        self.commit_prefix = commit_prefix
 
         # will instantiate & configure
         self.provider = provider

--- a/changelet/github.py
+++ b/changelet/github.py
@@ -100,6 +100,12 @@ class GitHubCli:
     def add_file(self, filename):
         run(['git', 'add', filename], check=True)
 
+    def has_staged(self):
+        result = run(
+            ['git', 'diff', '--staged'], check=True, capture_output=True
+        )
+        return len(result.stdout) > 0
+
     def commit(self, description):
         run(['git', 'commit', '-m', description], check=True)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ class TestConfig(TestCase):
         config = Config()
         self.assertEqual('', config.root)
         self.assertEqual('.changelog', config.directory)
+        self.assertEqual('Changelog: ', config.commit_prefix)
         self.assertEqual(
             {'class': 'changelet.github.GitHubCli'}, config._provider_config
         )
@@ -34,10 +35,14 @@ class TestConfig(TestCase):
     def test_overrides(self):
         klass = self.DummyProvider
         config = Config(
-            root='.foo', directory='.bar', provider={'class': klass}
+            root='.foo',
+            directory='.bar',
+            commit_prefix='abc: ',
+            provider={'class': klass},
         )
         self.assertEqual('.foo', config.root)
         self.assertEqual('.bar', config.directory)
+        self.assertEqual('abc: ', config.commit_prefix)
         self.assertIsInstance(config.provider, self.DummyProvider)
 
     def test_provider(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -187,6 +187,20 @@ class TestGitHubCli(TestCase):
         self.assertTrue(filename in args)
 
     @patch('changelet.github.run')
+    def test_has_staged(self, run_mock):
+        gh = GitHubCli()
+
+        run_mock.reset_mock()
+        run_mock.return_value = self.ResultMock('')
+        self.assertFalse(gh.has_staged())
+        run_mock.assert_called_once()
+
+        run_mock.reset_mock()
+        run_mock.return_value = self.ResultMock('There is output, thus changes')
+        self.assertTrue(gh.has_staged())
+        run_mock.assert_called_once()
+
+    @patch('changelet.github.run')
     def test_commit(self, run_mock):
         gh = GitHubCli()
         description = 'Hello World'


### PR DESCRIPTION
If there are staged changes the commit message and the change log entry are identical. If it's a change log msg only commit it's prefixed with `Changelog: `