### PR TITLE
Version 0.3.0 bump and changelog update

### DIFF
--- a/.changelog/a071cf491f214ba5845c5e737a607bdf.md
+++ b/.changelog/a071cf491f214ba5845c5e737a607bdf.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Testing out the new slash command

--- a/.changelog/c9ffeaab78fa4be5bc288077fda62636.md
+++ b/.changelog/c9ffeaab78fa4be5bc288077fda62636.md
@@ -1,4 +1,0 @@
----
-type: none
----
-A slash command for creating changelet entries

--- a/.changelog/ca8c7bff991043fea1cee4ffb5456fe7.md
+++ b/.changelog/ca8c7bff991043fea1cee4ffb5456fe7.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add commit prefix for changelog only commits

--- a/.changelog/fbcaac21b6034046848ed7b1a9e5f7e2.md
+++ b/.changelog/fbcaac21b6034046848ed7b1a9e5f7e2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Should be a fully working slash command now, issues worked out elsewhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0 - 2025-09-10
+
+Minor:
+* Add commit prefix for changelog only commits - [#14](https://github.com/octodns/changelet/pull/14)
+
 ## 0.2.0 - 2025-08-15
 
 Minor:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Not getting merged 
+
 ## ChangeLog and Release Management Tooling
 
 A simple standalone Python module for CHANGELOG and release management. Spun out of [octoDNS](https://github.com/octodns/octodns/).

--- a/changelet/__init__.py
+++ b/changelet/__init__.py
@@ -2,4 +2,4 @@
 #
 #
 
-__version__ = __VERSION__ = '0.2.0'
+__version__ = __VERSION__ = '0.3.0'


### PR DESCRIPTION

## 0.3.0 - 2025-09-10

Minor:
* Add commit prefix for changelog only commits - [#14](https://github.com/octodns/changelet/pull/14)