### PR TITLE
Version 0.5.0 bump & changelog update

### DIFF
--- a/.changelog/1518a1c136ba4f75bbf237f1e064eba5.md
+++ b/.changelog/1518a1c136ba4f75bbf237f1e064eba5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-remove stray  in grep path

--- a/.changelog/1ddf4bc9b8e54e7f81f5e57b6c51b948.md
+++ b/.changelog/1ddf4bc9b8e54e7f81f5e57b6c51b948.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add support for CHANGELET_GIT_ADD_ARGS and CHANGELET_GIT_COMMIT_ARGS environment variables to pass additional arguments to git commands

--- a/.changelog/224b2c2b670b44e1831be5882f1dc2cd.md
+++ b/.changelog/224b2c2b670b44e1831be5882f1dc2cd.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix startswith(directory) path prefix matching to avoid false matches on similarly named directories

--- a/.changelog/3bf8c98a9f3f4db08aeb3959c50afdf6.md
+++ b/.changelog/3bf8c98a9f3f4db08aeb3959c50afdf6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Black '26 formatting

--- a/.changelog/42b8eb625a9c46d986616ca5a239aa7a.md
+++ b/.changelog/42b8eb625a9c46d986616ca5a239aa7a.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Make base branch configurable in GitHubCli provider instead of hardcoding main

--- a/.changelog/56657db61f1f473a9fc5e4351b6457eb.md
+++ b/.changelog/56657db61f1f473a9fc5e4351b6457eb.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/57b84a8c6a6548899e549b73c0186bbb.md
+++ b/.changelog/57b84a8c6a6548899e549b73c0186bbb.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix has_staged check in create --commit to run before staging the entry

--- a/.changelog/623eee3b05d7487fb33993666cf806a1.md
+++ b/.changelog/623eee3b05d7487fb33993666cf806a1.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Limit _parse_file split to preserve --- in descriptions

--- a/.changelog/7dc4939c7bf347e08e013e8b9c77d0a5.md
+++ b/.changelog/7dc4939c7bf347e08e013e8b9c77d0a5.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Restore sys.path after _get_current_version import

--- a/.changelog/7eb5b8efb9c94dcf8cfd01a32b59f49c.md
+++ b/.changelog/7eb5b8efb9c94dcf8cfd01a32b59f49c.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Remove misleading None default from Config.load_yaml filename parameter

--- a/.changelog/8cc589ca115a46e795943a99b118e583.md
+++ b/.changelog/8cc589ca115a46e795943a99b118e583.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/9b6694d5009a43afbc6056cd8a331e9e.md
+++ b/.changelog/9b6694d5009a43afbc6056cd8a331e9e.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/a0841b0f4cc44ea5bc9ce666c271e7ba.md
+++ b/.changelog/a0841b0f4cc44ea5bc9ce666c271e7ba.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Migrate bump command subprocess calls to provider

--- a/.changelog/b43a6fe88e594e0b9af8e14b4e39e7bd.md
+++ b/.changelog/b43a6fe88e594e0b9af8e14b4e39e7bd.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/b6e425f51bf847eeb088d5007f0ca268.md
+++ b/.changelog/b6e425f51bf847eeb088d5007f0ca268.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Wire up EntryType enum for type validation

--- a/.changelog/c37790e807e5435880caf244328c3304.md
+++ b/.changelog/c37790e807e5435880caf244328c3304.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add --continue support

--- a/.changelog/c6148d9c5a4a4f81aa48fa6878ae8225.md
+++ b/.changelog/c6148d9c5a4a4f81aa48fa6878ae8225.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Add trailing newline when saving changelog entry files

--- a/.changelog/e31c0b73ef304f9ab92cd282fe3db71e.md
+++ b/.changelog/e31c0b73ef304f9ab92cd282fe3db71e.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Make module name configurable via Config instead of deriving from directory name in bump

--- a/.changelog/fd95e387e3db442892cc67f251d7f66c.md
+++ b/.changelog/fd95e387e3db442892cc67f251d7f66c.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Replace interactive git add -p with explicit file staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.5.0 - 2026-03-14
+
+Minor:
+* Make module name configurable via Config instead of deriving from directory name in bump - [#44](https://github.com/octodns/changelet/pull/44)
+* Make base branch configurable in GitHubCli provider instead of hardcoding main - [#43](https://github.com/octodns/changelet/pull/43)
+* Migrate bump command subprocess calls to provider - [#42](https://github.com/octodns/changelet/pull/42)
+* Replace interactive git add -p with explicit file staging - [#42](https://github.com/octodns/changelet/pull/42)
+* Add --continue support - [#32](https://github.com/octodns/changelet/pull/32)
+* Add support for CHANGELET_GIT_ADD_ARGS and CHANGELET_GIT_COMMIT_ARGS environment variables to pass additional arguments to git commands - [#28](https://github.com/octodns/changelet/pull/28)
+
+Patch:
+* Remove misleading None default from Config.load_yaml filename parameter - [#41](https://github.com/octodns/changelet/pull/41)
+* Wire up EntryType enum for type validation - [#40](https://github.com/octodns/changelet/pull/40)
+* Limit _parse_file split to preserve --- in descriptions - [#39](https://github.com/octodns/changelet/pull/39)
+* Restore sys.path after _get_current_version import - [#38](https://github.com/octodns/changelet/pull/38)
+* Add trailing newline when saving changelog entry files - [#35](https://github.com/octodns/changelet/pull/35)
+* Fix startswith(directory) path prefix matching to avoid false matches on similarly named directories - [#34](https://github.com/octodns/changelet/pull/34)
+* Fix has_staged check in create --commit to run before staging the entry - [#33](https://github.com/octodns/changelet/pull/33)
+
 ## 0.4.0 - 2025-11-26
 
 Minor:

--- a/changelet/__init__.py
+++ b/changelet/__init__.py
@@ -2,4 +2,4 @@
 #
 #
 
-__version__ = __VERSION__ = '0.4.0'
+__version__ = __VERSION__ = '0.5.0'


### PR DESCRIPTION
## 0.5.0 - 2026-03-14

Minor:
* Make module name configurable via Config instead of deriving from directory name in bump - [#44](https://github.com/octodns/changelet/pull/44)
* Make base branch configurable in GitHubCli provider instead of hardcoding main - [#43](https://github.com/octodns/changelet/pull/43)
* Migrate bump command subprocess calls to provider - [#42](https://github.com/octodns/changelet/pull/42)
* Replace interactive git add -p with explicit file staging - [#42](https://github.com/octodns/changelet/pull/42)
* Add --continue support - [#32](https://github.com/octodns/changelet/pull/32)
* Add support for CHANGELET_GIT_ADD_ARGS and CHANGELET_GIT_COMMIT_ARGS environment variables to pass additional arguments to git commands - [#28](https://github.com/octodns/changelet/pull/28)

Patch:
* Remove misleading None default from Config.load_yaml filename parameter - [#41](https://github.com/octodns/changelet/pull/41)
* Wire up EntryType enum for type validation - [#40](https://github.com/octodns/changelet/pull/40)
* Limit _parse_file split to preserve --- in descriptions - [#39](https://github.com/octodns/changelet/pull/39)
* Restore sys.path after _get_current_version import - [#38](https://github.com/octodns/changelet/pull/38)
* Add trailing newline when saving changelog entry files - [#35](https://github.com/octodns/changelet/pull/35)
* Fix startswith(directory) path prefix matching to avoid false matches on similarly named directories - [#34](https://github.com/octodns/changelet/pull/34)
* Fix has_staged check in create --commit to run before staging the entry - [#33](https://github.com/octodns/changelet/pull/33)

