### PR TITLE
Add --check flag to bump command

### DIFF
--- a/.changelog/0b0a6daec48045bcb374f89dd9faeca7.md
+++ b/.changelog/0b0a6daec48045bcb374f89dd9faeca7.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add --check flag to bump command for silent exit-code-only validation

--- a/changelet/command/bump.py
+++ b/changelet/command/bump.py
@@ -74,6 +74,11 @@ class Bump:
             help='Skip checking for local changes when using --pr',
         )
         parser.add_argument(
+            '--check',
+            action='store_true',
+            help='Silently check if a bump would happen and exit with 0 or 1',
+        )
+        parser.add_argument(
             'title', nargs='*', help='A short title/quip for the release title'
         )
 
@@ -119,6 +124,8 @@ class Bump:
             if args.version
             else _get_new_version(current_version, entries)
         )
+        if args.check:
+            return self.exit(0 if new_version else 1)
         if not new_version:
             print('No changelog entries found that would bump, nothing to do')
             return self.exit(1)

--- a/tests/test_command_bump.py
+++ b/tests/test_command_bump.py
@@ -34,12 +34,14 @@ class TestCommandBump(TestCase, AssertActionMixin):
             make_changes=False,
             pr=False,
             ignore_local_changes=False,
+            check=False,
         ):
             self.title = title
             self.make_changes = make_changes
             self.version = version
             self.pr = pr
             self.ignore_local_changes = ignore_local_changes
+            self.check = check
 
     def test_configure(self):
         create = Bump()
@@ -57,6 +59,7 @@ class TestCommandBump(TestCase, AssertActionMixin):
             flags=['--ignore-local-changes'],
             default=False,
         )
+        self.assert_action(actions['check'], flags=['--check'], default=False)
         # 3.12 made a change to * so that required=False, before that it was
         # True, for now we'll have to ignore it
         required = False if version_info >= (3, 12, 0) else None
@@ -97,6 +100,43 @@ class TestCommandBump(TestCase, AssertActionMixin):
             Entry(type='none', description='change 2'),
         ]
         self.assertIsNone(cmd.run(args=self.MockArgs(title), config=config))
+
+    @patch('changelet.command.bump.Bump.exit')
+    @patch('changelet.entry.Entry.load_all')
+    @patch('changelet.command.bump._get_current_version')
+    def test_check_would_bump(self, gcv_mock, ela_mock, exit_mock):
+        cmd = Bump()
+
+        config = Config('.cl', provider=None)
+
+        gcv_mock.return_value = Version.parse('0.1.3')
+        ela_mock.return_value = [Entry(type='minor', description='change 1')]
+
+        exit_mock.return_value = None
+        cmd.run(args=self.MockArgs([], check=True), config=config)
+        exit_mock.assert_called_once_with(0)
+
+    @patch('changelet.command.bump.Bump.exit')
+    @patch('changelet.entry.Entry.load_all')
+    @patch('changelet.command.bump._get_current_version')
+    def test_check_nothing_to_bump(self, gcv_mock, ela_mock, exit_mock):
+        cmd = Bump()
+
+        config = Config('.cl', provider=None)
+
+        gcv_mock.return_value = Version.parse('0.1.3')
+
+        # no entries
+        ela_mock.return_value = []
+        exit_mock.return_value = None
+        cmd.run(args=self.MockArgs([], check=True), config=config)
+        exit_mock.assert_called_once_with(1)
+
+        # only type none
+        exit_mock.reset_mock()
+        ela_mock.return_value = [Entry(type='none', description='change 1')]
+        cmd.run(args=self.MockArgs([], check=True), config=config)
+        exit_mock.assert_called_once_with(1)
 
     @patch('changelet.command.bump.Bump.exit')
     @patch('changelet.entry.Entry.load_all')
@@ -358,12 +398,14 @@ class TestCommandBumpPR(TestCase):
             make_changes=False,
             pr=False,
             ignore_local_changes=False,
+            check=False,
         ):
             self.title = title
             self.make_changes = make_changes
             self.version = version
             self.pr = pr
             self.ignore_local_changes = ignore_local_changes
+            self.check = check
 
     def _provider_mock(self, **overrides):
         provider = MagicMock()


### PR DESCRIPTION
## Summary

- Add `--check` flag to `bump` that silently checks whether a version bump would occur and exits with 0 (would bump) or 1 (nothing to bump)
- Useful for CI scripts that need to check bump status without producing output

## Test plan

- [x] New tests for `--check` with entries that would bump (exit 0)
- [x] New tests for `--check` with no entries and only `none`-type entries (exit 1)
- [x] All existing tests pass
- [x] 100% branch coverage maintained