### PR TITLE
Version 0.6.0 bump & changelog update

### DIFF
--- a/.changelog/0b0a6daec48045bcb374f89dd9faeca7.md
+++ b/.changelog/0b0a6daec48045bcb374f89dd9faeca7.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add --check flag to bump command for silent exit-code-only validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0 - 2026-04-03
+
+Minor:
+* Add --check flag to bump command for silent exit-code-only validation - [#46](https://github.com/octodns/changelet/pull/46)
+
 ## 0.5.0 - 2026-03-14
 
 Minor:

--- a/changelet/__init__.py
+++ b/changelet/__init__.py
@@ -2,4 +2,4 @@
 #
 #
 
-__version__ = __VERSION__ = '0.5.0'
+__version__ = __VERSION__ = '0.6.0'


### PR DESCRIPTION
## 0.6.0 - 2026-04-03

Minor:
* Add --check flag to bump command for silent exit-code-only validation - [#46](https://github.com/octodns/changelet/pull/46)

