### PR TITLE
Version 0.6.1 bump & changelog update

### DIFF
--- a/.changelog/09513edaa6574830aebd7c9f26c53601.md
+++ b/.changelog/09513edaa6574830aebd7c9f26c53601.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Remove defunct requirements-dev.txt

--- a/.changelog/335546799e034e709fd4143aae14c6d6.md
+++ b/.changelog/335546799e034e709fd4143aae14c6d6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/4a29ed7d672a43a0becee5ef3f2fc91e.md
+++ b/.changelog/4a29ed7d672a43a0becee5ef3f2fc91e.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Add --edit flag to bump command

--- a/.changelog/a7b21a722b6f4a73a6f1e54095b60bbf.md
+++ b/.changelog/a7b21a722b6f4a73a6f1e54095b60bbf.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1 - 2026-05-06
+
+Patch:
+* Add --edit flag to bump command - [#49](https://github.com/octodns/changelet/pull/49)
+
 ## 0.6.0 - 2026-04-03
 
 Minor:

--- a/changelet/__init__.py
+++ b/changelet/__init__.py
@@ -2,4 +2,4 @@
 #
 #
 
-__version__ = __VERSION__ = '0.6.0'
+__version__ = __VERSION__ = '0.6.1'


### PR DESCRIPTION
## 0.6.1 - 2026-05-06

Patch:
* Add --edit flag to bump command - [#49](https://github.com/octodns/changelet/pull/49)

