### PR TITLE
Improve --edit: use temp file and abort on editor errors

### DIFF
--- a/.changelog/7fb5a5eb72a54ed1961dc6299792dddf.md
+++ b/.changelog/7fb5a5eb72a54ed1961dc6299792dddf.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Edit only new changelog section in temp file, abort on editor errors

--- a/changelet/command/bump.py
+++ b/changelet/command/bump.py
@@ -6,11 +6,12 @@ from datetime import datetime
 from hashlib import sha256
 from importlib import import_module
 from io import StringIO
-from os import environ
+from os import environ, fdopen, unlink
 from os.path import join
 from shlex import split as shlex_split
 from subprocess import Popen
 from sys import exit, path, stderr
+from tempfile import mkstemp
 
 from semver import Version
 
@@ -178,13 +179,8 @@ class Bump:
             with open(changelog) as fh:
                 existing = fh.read()
 
-            with open(changelog, 'w') as fh:
-                fh.write(buf)
-                fh.write(existing)
-
             if args.edit:
-                combined = buf + existing
-                original_hash = sha256(combined.encode()).hexdigest()
+                original_hash = sha256(buf.encode()).hexdigest()
 
                 editor_cmd = (
                     environ.get('CHANGELET_EDITOR')
@@ -192,16 +188,33 @@ class Bump:
                     or environ.get('EDITOR')
                     or 'nano'
                 )
-                Popen(shlex_split(editor_cmd) + [changelog]).wait()
-
-                with open(changelog) as fh:
-                    buf = fh.read()
+                fd, tmp_path = mkstemp(suffix='.md')
+                try:
+                    with fdopen(fd, 'w') as fh:
+                        fh.write(buf)
+                    try:
+                        rc = Popen(shlex_split(editor_cmd) + [tmp_path]).wait()
+                    except OSError as e:
+                        print(f'Failed to open editor: {e}', file=stderr)
+                        return self.exit(1)
+                    if rc != 0:
+                        print(
+                            f'Editor exited with non-zero status {rc}, aborting.',
+                            file=stderr,
+                        )
+                        return self.exit(1)
+                    with open(tmp_path) as fh:
+                        buf = fh.read()
+                finally:
+                    unlink(tmp_path)
 
                 if sha256(buf.encode()).hexdigest() == original_hash:
-                    with open(changelog, 'w') as fh:
-                        fh.write(existing)
                     print('No changes made, aborting.')
                     return self.exit(1)
+
+            with open(changelog, 'w') as fh:
+                fh.write(buf)
+                fh.write(existing)
 
             init = join(root, module_name, '__init__.py')
             with open(init) as fh:

--- a/tests/test_command_bump.py
+++ b/tests/test_command_bump.py
@@ -8,7 +8,7 @@ from os import makedirs
 from os.path import basename, join
 from sys import path, version_info
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 from helpers import AssertActionMixin, TemporaryDirectory
 from semver import Version
@@ -302,7 +302,7 @@ Patch:
         )
 
         mock_proc = MagicMock()
-        mock_proc.wait.return_value = None
+        mock_proc.wait.return_value = 0
         popen_mock.return_value = mock_proc
 
         with TemporaryDirectory() as td:
@@ -330,6 +330,102 @@ Patch:
             )
 
             popen_mock.assert_called_once()
+            with open(changelog) as fh:
+                self.assertEqual('existing content\n', fh.read())
+            exit_mock.assert_called_once_with(1)
+
+    @patch('changelet.command.bump.Popen')
+    @patch('changelet.command.bump.environ')
+    @patch('changelet.command.bump.Bump.exit')
+    @patch('changelet.entry.Entry.load_all')
+    @patch('changelet.command.bump._get_current_version')
+    def test_edit_editor_not_found_aborts(
+        self, gcv_mock, ela_mock, exit_mock, environ_mock, popen_mock
+    ):
+        cmd = Bump()
+
+        gcv_mock.return_value = Version.parse('0.1.3')
+        ela_mock.return_value = [Entry(type='minor', description='change 1')]
+
+        environ_mock.get.side_effect = (
+            lambda key, default=None: default or 'nano'
+        )
+
+        popen_mock.side_effect = FileNotFoundError('nano not found')
+
+        with TemporaryDirectory() as td:
+            module_name = basename(td.dirname).replace('-', '_')
+
+            changelog = join(td.dirname, 'CHANGELOG.md')
+            with open(changelog, 'w') as fh:
+                fh.write('existing content\n')
+
+            init = join(td.dirname, module_name)
+            makedirs(init)
+            init = join(init, '__init__.py')
+            with open(init, 'w') as fh:
+                fh.write("# __version__ = '0.1.3' #")
+
+            config = Config(
+                join(td.dirname, '.cl'), module=module_name, provider=None
+            )
+
+            exit_mock.return_value = None
+            cmd.run(
+                self.MockArgs([], edit=True, make_changes=True),
+                config=config,
+                root=td.dirname,
+            )
+
+            with open(changelog) as fh:
+                self.assertEqual('existing content\n', fh.read())
+            exit_mock.assert_called_once_with(1)
+
+    @patch('changelet.command.bump.Popen')
+    @patch('changelet.command.bump.environ')
+    @patch('changelet.command.bump.Bump.exit')
+    @patch('changelet.entry.Entry.load_all')
+    @patch('changelet.command.bump._get_current_version')
+    def test_edit_editor_nonzero_exit_aborts(
+        self, gcv_mock, ela_mock, exit_mock, environ_mock, popen_mock
+    ):
+        cmd = Bump()
+
+        gcv_mock.return_value = Version.parse('0.1.3')
+        ela_mock.return_value = [Entry(type='minor', description='change 1')]
+
+        environ_mock.get.side_effect = (
+            lambda key, default=None: default or 'nano'
+        )
+
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 1
+        popen_mock.return_value = mock_proc
+
+        with TemporaryDirectory() as td:
+            module_name = basename(td.dirname).replace('-', '_')
+
+            changelog = join(td.dirname, 'CHANGELOG.md')
+            with open(changelog, 'w') as fh:
+                fh.write('existing content\n')
+
+            init = join(td.dirname, module_name)
+            makedirs(init)
+            init = join(init, '__init__.py')
+            with open(init, 'w') as fh:
+                fh.write("# __version__ = '0.1.3' #")
+
+            config = Config(
+                join(td.dirname, '.cl'), module=module_name, provider=None
+            )
+
+            exit_mock.return_value = None
+            cmd.run(
+                self.MockArgs([], edit=True, make_changes=True),
+                config=config,
+                root=td.dirname,
+            )
+
             with open(changelog) as fh:
                 self.assertEqual('existing content\n', fh.read())
             exit_mock.assert_called_once_with(1)
@@ -373,6 +469,7 @@ Patch:
                     content = fh.read()
                 with open(self.path, 'w') as fh:
                     fh.write(content.replace('change 1', 'change 1 - edited'))
+                return 0
 
         popen_mock.side_effect = EditingProcess
 
@@ -488,6 +585,7 @@ Patch:
                     content = fh.read()
                 with open(self.path, 'w') as fh:
                     fh.write(content.replace('change 1', 'change 1 - edited'))
+                return 0
 
         popen_mock.side_effect = EditingProcess
 
@@ -519,7 +617,7 @@ Patch:
                 root=td.dirname,
             )
 
-            popen_mock.assert_called_once_with(['vim', '-f', changelog])
+            popen_mock.assert_called_once_with(['vim', '-f', ANY])
 
     @patch('changelet.command.bump.Popen')
     @patch('changelet.command.bump.environ')
@@ -560,6 +658,7 @@ Patch:
                     content = fh.read()
                 with open(self.path, 'w') as fh:
                     fh.write(content.replace('change 1', 'change 1 - edited'))
+                return 0
 
         popen_mock.side_effect = EditingProcess
 
@@ -593,7 +692,7 @@ Patch:
 
             # shlex.split preserves quotes as single argument boundaries
             popen_mock.assert_called_once_with(
-                ['code --wait', '--new-window', changelog]
+                ['code --wait', '--new-window', ANY]
             )
 
 


### PR DESCRIPTION
- Edit only the new changelog section in a temporary file rather than the full `CHANGELOG.md`, keeping the edit focused and fixing the bug where the full changelog was used as the PR body
- Abort with an error if the editor cannot be launched (`OSError`) or exits with a non-zero status